### PR TITLE
don't scale up the mastodon holding fairydust

### DIFF
--- a/stylesheets/custom.scss
+++ b/stylesheets/custom.scss
@@ -3,3 +3,7 @@
 .column, .drawer {
   flex: 1 1 auto;
 }
+
+.getting-started {
+  background: image-url('mastodon-getting-started.png') no-repeat 0 100% local;
+}


### PR DESCRIPTION
With the wider column layout the mastodon on the welcome column gets scaled up and starts to get pixelated.

Since we can't make the image larger without redrawing the original (perhaps later), fix the pixelation by not scaling the image up.