### PR TITLE
fix columns not being full width on responsive single column view

### DIFF
--- a/stylesheets/custom.scss
+++ b/stylesheets/custom.scss
@@ -1,6 +1,8 @@
 @import 'application';
 
-.column, .drawer {
-  flex: 1 1 auto;
-  max-width: 400px;
+@media screen and (min-width: 1025px) {
+  .column, .drawer {
+    flex: 1 1 auto;
+    max-width: 400px;
+  }
 }


### PR DESCRIPTION
On small screens (mobile), the web interface renders only one column in full width.
Limit the "max-width" rule to large screens.
(this is the same media query used for shrinking the original columns on large screens).