### PR TITLE
Set max-width from 400px to 580px

### DIFF
--- a/themes/custom.scss
+++ b/themes/custom.scss
@@ -6,6 +6,10 @@
     min-width: 300px;
     max-width: 580px;
   }
+
+  .ui.is-composing .column, .ui.is-composing .drawer {
+    max-width: 400px;
+  }
 }
 
 .drawer__inner {

--- a/themes/custom.scss
+++ b/themes/custom.scss
@@ -4,7 +4,7 @@
   .column, .drawer {
     flex: 1 1 auto;
     min-width: 300px;
-    max-width: 400px;
+    max-width: 580px;
   }
 }
 


### PR DESCRIPTION
Currently, when using the standard UI (not the advanced, multi-column one), the main column is displayed with a maximum width of 400 pixels, despite the layout providing more space for it.

The following screenshot represents the situation on a 13" MacBook (Retina display):

<img width="1280" alt="grafik" src="https://user-images.githubusercontent.com/273727/60388810-d2085e80-9ab6-11e9-9596-af6e45262d0c.png">

Here is a preview how the change in this PR affects the screen:

<img width="1280" alt="grafik" src="https://user-images.githubusercontent.com/273727/60388823-fe23df80-9ab6-11e9-9607-3c033f6920ac.png">

I might be ignorant regarding side effects of this change.