### PR TITLE
Apply custom column width only in advanced view

### DIFF
--- a/themes/custom.scss
+++ b/themes/custom.scss
@@ -1,7 +1,8 @@
 @import 'application';
 
 @media screen and (min-width: 1025px) {
-  .column, .drawer {
+  .layout-multiple-columns .column,
+  .layout-multiple-columns .drawer {
     flex: 1 1 auto;
     min-width: 300px;
     max-width: 400px;


### PR DESCRIPTION
Hi y'all, thanks for your work in providing all of us such a great home on chaos.social! I'd like to propose a fix to an issue I've been noticing as a user of the new simplified mastodon theme:

The chaos.social default theme widens the columns in the multi-column (advanced) view (which is awesome and shouldn't change). However, the maximum width also applied to the new single-column (standard) view, so that toots didn't use all available space.

This PR changes the CSS selectors on the theme customization to limit the width change to the multi-column view, allowing the timeline to take up the full width in the new standard view, too.

Here's the before/after:

![Before](https://user-images.githubusercontent.com/8349942/67160802-c0441300-f354-11e9-8c44-b02f604c5847.png)

![After](https://user-images.githubusercontent.com/8349942/67160803-c4703080-f354-11e9-8edb-41d82b0089b7.png)

Please let me know if there's anything I can do to make sure this is production-worthy on your instance. I've applied the change via developer tools and it doesn't seem to break anything I can see, but if you have ideas for more rigorous testing, I'd be happy to do that for you.

Thanks again, and kind regards, -Felix