### PR TITLE
Allow "normal-sized" embedded videos (Fix #15)

### DIFF
--- a/themes/custom.scss
+++ b/themes/custom.scss
@@ -157,7 +157,7 @@ $font-monospace: 'mastodon-font-monospace' !default;
     padding: 8px 12px;
 }
 .status-card__image {
-    flex: 0 0 76px;
+    flex: 0 0 auto;
 }
 .status-card__image,
 .status-card__image-image,


### PR DESCRIPTION
Allowing .status-card__image flex-basis to 'auto' instead of 76px allows embedded videos to grow to fill the available screen estate provided, instead of having it shrinked to 76px.

This fixes issue #15